### PR TITLE
YAML parser: Añadido soporte para expresiones booleanas

### DIFF
--- a/models/YamlExpression.php
+++ b/models/YamlExpression.php
@@ -1,0 +1,58 @@
+<?php
+class Klear_Model_YamlExpression
+{
+
+
+    /**
+     * Check a given YAML expression only has valid values
+     *
+     * @param unknown_type $string
+     */
+    public static function checkTokens($string)
+    {
+        $validStringTokens = array("true", "false", ";", ">", "<", "(", ")");
+        $string = trim($string);
+        $tokens = token_get_all("<?php " . $string . " ?>");
+
+        foreach ($tokens as $idToken => $token) {
+
+            if (is_string($token)) {
+                // Check if the string is one of the supported strings
+                if (!in_array($token, $validStringTokens)) {
+                    throw new Exception("Invalid token string in YAML expression:" . $string . ' ' . $token);
+                }
+                continue;
+            }
+
+            switch(token_name($token[0])) {
+                case 'T_STRING':
+                    // Check if the string is one of the supported strings
+                    if (!in_array($token[1], $validStringTokens)) {
+                        throw new Exception("Invalid token string in YAML expression:" . $string . ' ' . $token);
+                    }
+                    break;
+                case 'T_OPEN_TAG':
+                case 'T_CLOSE_TAG':
+                case 'T_RETURN':
+                case 'T_LNUMBER':
+                case 'T_WHITESPACE':
+                case 'T_IS_EQUAL':              // ==
+                case 'T_IS_GREATER_OR_EQUAL':   // >=
+                case 'T_IS_IDENTICAL':          // ===
+                case 'T_IS_NOT_EQUAL':          // != or <>
+                case 'T_IS_NOT_IDENTICAL':      // ===
+                case 'T_IS_SMALLER_OR_EQUAL':   // <=
+                case 'T_LOGICAL_AND':           // and
+                case 'T_LOGICAL_OR':            // or
+                case 'T_BOOLEAN_AND':           // &&
+                case 'T_BOOLEAN_OR':            // ||
+                    break;
+                default:
+                    Throw Exception("Invalid token in YAML expression");
+                    break;
+            }
+        }
+
+        return $string;
+    }
+}

--- a/models/YamlStream.php
+++ b/models/YamlStream.php
@@ -193,7 +193,9 @@ class Klear_Model_YamlStream
 
     protected function _parseExpression($data)
     {
-        $value = (bool) eval ("return (" . $data[1] . ");");
+        // Check expression has only allowed tokens
+        $expr = Klear_Model_YamlExpression::checkTokens("return (" . $data[1] . ");");
+        $value = (bool) eval ($expr);
         return $value ? 'true' : 'false';
     }
 

--- a/models/YamlStream.php
+++ b/models/YamlStream.php
@@ -30,6 +30,7 @@ class Klear_Model_YamlStream
         $this->_content = $this->_loadContent($this->_file);
 
         $this->_resolveVariables();
+        $this->_resolveExpressions();
         $this->_fixGettextInvocations();
 
         $this->_length = mb_strlen($this->_content, '8bit');
@@ -186,6 +187,21 @@ class Klear_Model_YamlStream
         $this->_content = preg_replace_callback(
             '/\$\{([^\}]*)\}/',
             array($this, '_parseVariables'),
+            $this->_content
+        );
+    }
+
+    protected function _parseExpression($data)
+    {
+        $value = (bool) eval ("return (" . $data[1] . ");");
+        return $value ? 'true' : 'false';
+    }
+
+    protected function _resolveExpressions()
+    {
+        $this->_content = preg_replace_callback(
+            '/\$\[([^\]]*)\]/',
+            array($this, '_parseExpression'),
             $this->_content
         );
     }


### PR DESCRIPTION
Este cambio, basado en la lógica de sustitucion actual de variables en los
ficheros de configuración de klear, permite incluir expresiones booleanas.

Las expresiones se deben encapsular entre los tags especiales $[ ] y se
evaluarán como una expresión en PHP, pudiendo devolver 'true' o 'false'.

Esta evaluación se hará **después** de la sustitución de variables, por lo que
la expressión puede contener variables sustituidas.

Esto puede ser especialmente práctico para evaluar blacklists, inclusiones de
botones o pantallas, etc en base a más de una variable, por ejemplo:

``` 
fields:
  blacklist:
    name: $[${auth.variable1} && ${auth.variable2}]
```

Aunque cualquier expressión que de devuelva un valor evaluable es válida

```
fields:
  screens:                                                              
     configurationEdit_screen: $[${auth.accessLevel} >=4]
```
 

 