### PR TITLE
Add tag exception to silence deprecation warnings in php8.2

### DIFF
--- a/models/YamlStream.php
+++ b/models/YamlStream.php
@@ -6,6 +6,7 @@
 * @author jabi
 *
 */
+#[AllowDynamicProperties]
 class Klear_Model_YamlStream
 {
     protected $_protocol = 'klear.yaml://';


### PR DESCRIPTION
This tag allows ignoring dynamic properties deprectation warnings:

```
Creation of dynamic property Klear_Model_YamlStream::$context is deprecated (0) # /usr/share/php/Zend/Config/Yaml.php(175)